### PR TITLE
Fix stray bootloader line

### DIFF
--- a/bootloader/codex16_bootloader.py
+++ b/bootloader/codex16_bootloader.py
@@ -1,5 +1,3 @@
-codex16_bootloader_hardened_phase1)
-
 """
 Nightwalker AI v4.6 – Codex16 Bootloader (Hardened Phase 1)
 Implements RSA-4096 verification, secure YAML parsing, and NIST-compatible logging.


### PR DESCRIPTION
## Summary
- remove leftover codex16 bootloader header

## Testing
- `python3 -m py_compile bootloader/codex16_bootloader.py`
