### PR TITLE
Fix header in bootloader script

### DIFF
--- a/bootloader/codex16_bootloader.py
+++ b/bootloader/codex16_bootloader.py
@@ -1,7 +1,6 @@
-codex16_bootloader_hardened_phase1)
-
 """
-Nightwalker AI v4.6 – Codex16 Bootloader (Hardened Phase 1)
+Codex16 Bootloader (Hardened Phase 1)
+Nightwalker AI v4.6
 Implements RSA-4096 verification, secure YAML parsing, and NIST-compatible logging.
 """
 


### PR DESCRIPTION
## Summary
- clean up codex16 bootloader header

## Testing
- `python3 -m py_compile bootloader/codex16_bootloader.py`
- `python3 bootloader/codex16_bootloader.py` *(fails: ModuleNotFoundError: No module named 'yaml')*